### PR TITLE
chore: 修改md安装说明，复制不再弹alert，demo展示溢出隐藏

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ pnpm-debug.log*
 # Editor directories and files
 .idea
 .vscode
+.history
 *.suo
 *.ntvs*
 *.njsproj

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Vitepress-Theme-Demoblock 参考了 [Element UI](https://github.com/element-plus
 ## 安装
 
 ```bash
-npm install vitepress-theme-demoblock
-yarn add vitepress-theme-demoblock
+npm install vitepress-theme-demoblock --save-dev
+yarn add -D vitepress-theme-demoblock
 ```
 
 

--- a/components/Demo.vue
+++ b/components/Demo.vue
@@ -1,8 +1,8 @@
 <template>
   <div
-      :class="['demo-block', blockClass, customClass ? customClass : '', { hover } ]"
-      @mouseenter="hover=true"
-      @mouseleave="hover=false">
+    :class="['demo-block', blockClass, customClass ? customClass : '', { hover } ]"
+    @mouseenter="hover=true"
+    @mouseleave="hover=false">
     <div class="source">
       <slot />
     </div>
@@ -27,7 +27,7 @@
       </transition>
       <div class="control-button-wrap">
         <transition name="text-slide">
-          <span v-show="isExpanded" class="control-button copy-button" @click.stop="onCopy">{{ locale && locale['copy-button-text'] }}</span>
+          <span v-show="isExpanded" class="control-button copy-button" @click.stop="onCopy">{{ copyText }}</span>
         </transition>
       </div>
     </div>
@@ -51,6 +51,7 @@ export default {
     const hover = ref(false)
     const fixedControl = ref(false)
     const isExpanded = ref(false)
+    const isShowTip = ref(false)
     // const codepen = reactive({
     //   html: stripTemplate(props.sourceCode),
     //   script: stripScript(props.sourceCode),
@@ -73,8 +74,13 @@ export default {
       return data.theme.value.demoblock?.[data.localePath.value] ?? {
         'hide-text': '隐藏代码',
         'show-text': '显示代码',
-        'copy-button-text': '复制代码片段'
+        'copy-button-text': '复制代码片段',
+        'copy-button-text-success': '复制成功！'
       }
+    })
+
+    const copyText = computed(() => {
+      return isShowTip.value ? locale.value['copy-button-text-success'] : locale.value['copy-button-text']
     })
 
     const controlText = computed(() => {
@@ -107,7 +113,10 @@ export default {
 
     const onCopy = () => {
       clipboardCopy(props.sourceCode)
-      alert('复制成功')
+      isShowTip.value = true
+      setTimeout(() => {
+        isShowTip.value = false
+      }, 2000)
     }
 
     const goCodepen = () => {}
@@ -139,7 +148,7 @@ export default {
       removeScrollHandler()
     })
 
-    return { blockClass, hover, fixedControl, isExpanded, locale, controlText, highlight, description, meta, control, onCopy }
+    return { blockClass, hover, fixedControl, isExpanded, locale, controlText, copyText, highlight, description, meta, control, onCopy }
   }
 }
 </script>
@@ -160,6 +169,7 @@ export default {
   box-sizing: border-box;
   padding: 24px;
   transition: .2s;
+  overflow: auto;
 }
 
 .meta {

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -28,12 +28,14 @@ module.exports = {
       '/': {
         'hide-text': 'Hide',
         'show-text': 'Expand',
-        'copy-button-text': 'Copy'
+        'copy-button-text': 'Copy',
+        'copy-button-text-success': 'Copy success!'
       },
       '/zh': {
         'hide-text': '隐藏代码',
         'show-text': '显示代码',
-        'copy-button-text': '复制代码片段'
+        'copy-button-text': '复制代码片段',
+        'copy-button-text-success': '复制成功！'
       }
     },
 


### PR DESCRIPTION
1. 插件最好是在devDependencies中安装，所以修改了README.md安装说明
2. 复制不再弹alert，会替换复制文案，2s后恢复

![image](https://user-images.githubusercontent.com/29355875/129922663-2424916a-8a6d-4244-a323-75fbd3c0c4b9.png)

**`修改后`**

![image](https://user-images.githubusercontent.com/29355875/129922722-216f363f-b100-4cc0-a0fa-fe6c9bfd0acc.png)
---
3. demo展示超过最大宽度过后会超出范围，增加溢出隐藏

![image](https://user-images.githubusercontent.com/29355875/129922484-4711c557-562c-4d15-ae17-cd45212467d3.png)

**`修改后`**

![image](https://user-images.githubusercontent.com/29355875/129922874-b2cc9c5a-44bf-4d13-b1dd-c10b9708744f.png)

