### PR TITLE
fix(Demo): 修复窗口缩放时，底部 demo-block-control 的宽度和位置不准确问题

### DIFF
--- a/components/Demo.vue
+++ b/components/Demo.vue
@@ -1,5 +1,6 @@
 <template>
   <div
+    ref="demoBlock"
     :class="['demo-block', blockClass, customClass ? customClass : '', { hover }]"
     @mouseenter="hover = true"
     @mouseleave="hover = false"
@@ -116,6 +117,7 @@ export default {
     const description = ref(null)
     const meta = ref(null)
     const control = ref(null)
+    const demoBlock = ref(null)
 
     const codeAreaHeight = computed(() => {
       if (description.value) {
@@ -129,10 +131,12 @@ export default {
       const innerHeight = window.innerHeight || document.body.clientHeight
       fixedControl.value = bottom > innerHeight && top + 44 <= innerHeight
       control.value.style.left = fixedControl.value ? `${left}px` : '0'
+      control.value.style.width = `${demoBlock.value.offsetWidth}px`
     }
     const scrollHandler = throttle(_scrollHandler, 200)
     const removeScrollHandler = () => {
       window.removeEventListener('scroll', scrollHandler)
+      window.removeEventListener('resize', scrollHandler)
     }
 
     const onCopy = () => {
@@ -155,6 +159,7 @@ export default {
       }
       setTimeout(() => {
         window.addEventListener('scroll', scrollHandler)
+        window.addEventListener('resize', scrollHandler)
         _scrollHandler()
       }, 300)
     })
@@ -183,7 +188,8 @@ export default {
       description,
       meta,
       control,
-      onCopy
+      onCopy,
+      demoBlock
     }
   }
 }
@@ -245,7 +251,7 @@ export default {
 .demo-block-control.is-fixed {
   position: fixed;
   bottom: 0;
-  width: calc(100% - 320px - 48px - 200px - 1px);
+  /* width: calc(100% - 320px - 48px - 200px - 1px); */
   border-right: solid 1px #eaeefb;
   z-index: 1;
 }


### PR DESCRIPTION
1. 屏幕缩放到小于 993 px 情况下，底部 demo-block-control 的位置与 demo-block 不对齐，同时宽度也小于 demo-block。
2. 什么时候会遇到屏幕小于 993px 呢，当用户打开 devtool 控制台调试的时候。
3. 解决：根据屏幕缩放动态计算宽度和位置进行校准。