### PR TITLE
fix: undefined data in renderPlugin

### DIFF
--- a/demoblock/index.js
+++ b/demoblock/index.js
@@ -64,7 +64,7 @@ const renderPlugin = (md, options) => {
     if (result.indexOf(startTag) !== -1 && result.indexOf(endTag) !== -1) {
       const { template, script, style } = renderDemoBlock(result, options)
       result = template
-      const data = md.__data
+      const data = md.__data || {}
       const hoistedTags = data.hoistedTags || (data.hoistedTags = [])
       hoistedTags.push(script)
       hoistedTags.push(style)


### PR DESCRIPTION
In my case, there is not a`__data` in` md` then it cause a crash.