### PR TITLE
当源码需要用到client-only标签时，demo中的client-only自动删除功能

### DIFF
--- a/src/node/demoblock.ts
+++ b/src/node/demoblock.ts
@@ -18,8 +18,9 @@ export const blockPlugin = (md: MarkdownIt, options: DemoblockPluginOptions) => 
       if (tokens[idx].nesting === 1) {
         // const description = m && m.length > 1 ? m[1] : ''
         const content = tokens[idx + 1].type === 'fence' ? tokens[idx + 1].content : ''
+        const contents = content.replace('<client-only>', '').replace('</client-only>', '')
         return `<demo customClass="${options.customClass}" sourceCode="${md.utils.escapeHtml(
-          content
+          contents
         )}">${content ? `<!--vue-demo:${content}:vue-demo-->` : ''}`
       }
       return '</demo>'
@@ -45,6 +46,7 @@ export const codePlugin = (md: MarkdownIt, options: DemoblockPluginOptions) => {
     if (token.info.trim() === lang && isInDemoContainer) {
       const m = prevToken.info.trim().match(/^demo\s*(.*)$/)
       const description = m && m.length > 1 ? m[1] : ''
+      const content = token.content.replace('<client-only>', '').replace('</client-only>', '')
       return `
         ${
           description
@@ -55,7 +57,7 @@ export const codePlugin = (md: MarkdownIt, options: DemoblockPluginOptions) => {
         }
         <template #highlight>
           <div v-pre class="language-${lang}">
-            ${md.options.highlight?.(token.content, lang, '') || ''}
+            ${md.options.highlight?.(content, lang, '') || ''}
           </div>
         </template>`
     }

--- a/src/theme/styles/index.css
+++ b/src/theme/styles/index.css
@@ -5,17 +5,18 @@
   /*--vp-c-brand-lightest: #bcc0ff;*/
   /*--vp-c-brand-dark: #535bf2;*/
   /*--vp-c-brand-darker: #454ce1;*/
-  --demoblock-border: var(--vp-c-divider-light);
+  --demoblock-border: rgba(60, 60, 60, 0.12);
   --demoblock-control: #d3dce6;
   --demoblock-control-bg: var(--vp-c-bg);
   --demoblock-control-bg-hover: #f9fafc;
-  --demoblock-description-bg: var(--vp-c-bg);
+  --demoblock-description-bg: var(--vp-c-bg, #ffffff);
 }
 
 html.dark {
   --demoblock-control: #8b9eb0;
   --demoblock-control-bg-hover: var(--vp-c-bg);
-  --demoblock-description-bg: var(--vp-code-bg-color);
+  --demoblock-description-bg: var(--vp-code-bg-color, #1a1a1a);
+  --demoblock-border: rgba(84, 84, 84, 0.48);
 }
 
 /* icon-caret */


### PR DESCRIPTION
1.当源码需要用到client-only标签时，demo中的client-only自动删除功能，使得用户不会复制demo核心代码外的client-only标签。
2.vitepress升级导致的css变量丢失导致样式问题。