### PR TITLE
feat: add support for Markdown File Inclusion

### DIFF
--- a/playground/vitepress/guide/inclusion/basic.md
+++ b/playground/vitepress/guide/inclusion/basic.md
@@ -1,6 +1,6 @@
-# Card
+##  来自 inclusion
 
-常用的卡片布局。
+inclusion 中
 
 ## 基础用法 <Badge type="info" text="default" />
 
@@ -150,14 +150,4 @@ export default defineComponent({
 ```
 
 :::
-
-<script setup>
-console.log('vitepress-theme-demoblock setup')
-</script>
-
-<script>
-console.log('vitepress-theme-demoblock')
-</script>
-
-<!--@include: ./inclusion/basic.md-->
 

--- a/src/node/processIncludes.ts
+++ b/src/node/processIncludes.ts
@@ -1,0 +1,36 @@
+// 拷贝自 vitepress
+import path from 'path'
+import fs from 'node:fs'
+
+const includesRE = /<!--\s*@include:\s*(.*?)\s*-->/g
+const rangeRE = /\{(\d*),(\d*)\}$/
+
+export function processIncludes(code: string, file: string, root: string): string {
+  return code.replace(includesRE, (m: string, m1: string) => {
+    if (!m1.length) return m
+
+    const range = m1.match(rangeRE)
+    range && (m1 = m1.slice(0, -range[0].length))
+    const atPresent = m1[0] === '@'
+    try {
+      const includePath = atPresent
+        ? path.join(root, m1.slice(m1[1] === '/' ? 2 : 1))
+        : path.join(path.dirname(file), m1)
+      let content = fs.readFileSync(includePath, 'utf-8')
+      if (range) {
+        const [, startLine, endLine] = range
+        const lines = content.split(/\r?\n/)
+        content = lines
+          .slice(
+            startLine ? parseInt(startLine, 10) - 1 : undefined,
+            endLine ? parseInt(endLine, 10) : undefined
+          )
+          .join('\n')
+      }
+      // recursively process includes in the content
+      return processIncludes(content, includePath, root)
+    } catch (error) {
+      return m // silently ignore error if file is not present
+    }
+  })
+}

--- a/src/node/remark.ts
+++ b/src/node/remark.ts
@@ -9,6 +9,7 @@ import path from 'path'
 import os from 'os'
 import h from 'hash-sum'
 import { ScriptSetupMatchPattern } from './patterns'
+import { processIncludes } from './processIncludes'
 
 export const demoPattern = /:::demo([\s\S]*?):::/
 export const codePattern = /.md.demo.[a-zA-Z0-9]+\.(vue|jsx|tsx)$/
@@ -78,7 +79,7 @@ export async function transformCodeToComponent(
       }
     }
   }
-
+  code = processIncludes(code, id, options.root)
   const file = await unified()
     .use(remarkParse)
     .use(remarkFrontmatter)


### PR DESCRIPTION
拷贝`vitepress`的 `processIncludes`的代码，来支持 ` vitepress ` [Markdown File Inclusion](https://vitepress.dev/guide/markdown#markdown-file-inclusion)