### PR TITLE
fix: 修复vitepress-theme-demoblock包依赖协议头link为npm所支持的file

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "unified": "^11.0.4",
     "unist-util-visit": "^5.0.0",
     "vitepress": "^1.6.3",
-    "vitepress-theme-demoblock": "link:",
+    "vitepress-theme-demoblock": "file:./",
     "vue": "^3.4.21",
     "yaml": "^2.4.1"
   },


### PR DESCRIPTION
#68 