### PR TITLE
fix: 添加 remark-gfm 以正确处理 GFM 表格中的转义字符

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "remark": "^15.0.1",
     "remark-directive": "^3.0.0",
     "remark-frontmatter": "^5.0.0",
+    "remark-gfm": "^4.0.0",
     "remark-parse": "^11.0.0",
     "remark-stringify": "^11.0.0",
     "shiki": "^1.2.0",

--- a/src/node/remark.ts
+++ b/src/node/remark.ts
@@ -2,6 +2,7 @@ import { unified } from 'unified'
 import remarkParse from 'remark-parse'
 import remarkFrontmatter from 'remark-frontmatter'
 import remarkDirective from 'remark-directive'
+import remarkGfm from 'remark-gfm'
 import remarkStringify from 'remark-stringify'
 import type { Node } from 'unist'
 import { visit } from 'unist-util-visit'
@@ -82,6 +83,7 @@ export async function transformCodeToComponent(
   code = processIncludes(code, id, options.root)
   const file = await unified()
     .use(remarkParse)
+    .use(remarkGfm)
     .use(remarkFrontmatter)
     .use(remarkDirective)
     .use(remarkStringify)


### PR DESCRIPTION
## 问题描述

表格是 GFM（GitHub Flavored Markdown）的特性，不是 CommonMark 的一部分。在没有 `remark-gfm` 的情况下，markdown 表格中的转义管道符（`\|`）会在 remark 的 parse-stringify 过程中被错误地去除。

### 示例

**修复前：**
```markdown
输入:  | Type | boolean\|number |
输出:  | Type | boolean|number |  ← 转义丢失，表格结构错乱！
```

**修复后：**
```markdown
输入:  | Type | boolean\|number |
输出:  | Type | boolean\|number |  ← 转义正确保留 ✓
```

### 根本原因

正如 [remarkjs/remark#929](https://github.com/remarkjs/remark/issues/929) 中所解释的：

> "Tables are a GFM (GitHub Flavored Markdown) feature, not part of CommonMark. GFM is not supported by remark by default."

当 remark 在没有 `remark-gfm` 插件的情况下处理内容时，它会将 `\|` 视为不必要的转义（因为普通 markdown 中 `|` 没有特殊用途），从而将其移除。

## 解决方案

在 unified 处理流程中添加 `remark-gfm`，以正确处理 GFM 表格语法，包括表格单元格中的转义字符。

## 修改内容

- 添加 `remark-gfm` 依赖
- 在 `remark.ts` 的 unified 处理链中添加 `.use(remarkGfm)`

## 测试

已在本地验证，带有转义管道符的 markdown 表格现在可以正确渲染：

```markdown
| Prop | Type | Default |
| --- | --- | --- |
| splitter | boolean\|number | true |
```